### PR TITLE
Fix Maven API calls to include organization in package name

### DIFF
--- a/src/main/java/com/sourceauditor/spdx_to_osv/ExternalRefParser.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/ExternalRefParser.java
@@ -32,7 +32,7 @@ public class ExternalRefParser {
 	static final Pattern SWH_PATTERN = Pattern.compile("swh:1:(cnt|dir|rev|rel|snp):([0123456789abcdef]{40})$");
     static final Pattern PURL_PATTERN = Pattern.compile("pkg:((?<type>[^?/#@]+)/)((?<namespace>[^?#@]+)/)?(?<name>[^?#@]+)(@(?<version>[^?#]+))?(\\?[^#]+)*(#.+)*$");
 	
-    private boolean useMavenGroupInPkgName = false;
+    private boolean useMavenGroupInPkgName = true;
 	private ExternalRef externalRef;
     Optional<OsvVulnerabilityRequest> osvVulnerabilityRequest = Optional.empty();
     Optional<Part> cpePart = Optional.empty();
@@ -53,7 +53,7 @@ public class ExternalRefParser {
      * @throws SwhException
      */
     public ExternalRefParser(ExternalRef externalRef) throws InvalidSPDXAnalysisException, InvalidExternalRefPattern, IOException, SwhException {
-    	this(externalRef, false);
+    	this(externalRef, true);
     }
 
     /**
@@ -214,7 +214,7 @@ public class ExternalRefParser {
         cpePart = Optional.of(Part.APPLICATION);
         String pkg;
         if (this.useMavenGroupInPkgName) {
-        	pkg = parts[0] + "." + parts[1];
+        	pkg = parts[0] + ":" + parts[1];
         } else {
         	pkg = parts[1];
         }

--- a/src/main/java/com/sourceauditor/spdx_to_osv/OsvApi.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/OsvApi.java
@@ -60,7 +60,8 @@ public class OsvApi {
      */
     public List<OsvVulnerability> queryVulnerabilities(OsvVulnerabilityRequest packageNameVersion) throws IOException, SpdxToOsvException {
         HttpURLConnection con = (HttpURLConnection)(apiUrl.openConnection());
-        byte[] json = GSON.toJson(packageNameVersion).getBytes(StandardCharsets.UTF_8);
+        String pkgNameVersionJson = GSON.toJson(packageNameVersion);
+        byte[] json = pkgNameVersionJson.getBytes(StandardCharsets.UTF_8);
         int len = json.length;
         con.setRequestMethod("POST");
         con.setFixedLengthStreamingMode(len);

--- a/src/test/java/com/sourceauditor/spdx_to_osv/ExternalRefParserTest.java
+++ b/src/test/java/com/sourceauditor/spdx_to_osv/ExternalRefParserTest.java
@@ -325,7 +325,7 @@ public class ExternalRefParserTest {
     	ExternalRef er = spdxPackage.createExternalRef(ReferenceCategory.PACKAGE_MANAGER, 
                 ListedReferenceTypes.getListedReferenceTypes().getListedReferenceTypeByName("maven-central"), 
                 "org.spdx:tools-java:2.2.2", null);
-    	ExternalRefParser erp = new ExternalRefParser(er);
+    	ExternalRefParser erp = new ExternalRefParser(er, false);
     	Optional<OsvVulnerabilityRequest> ovr = erp.osvVulnerabilityRequest();
     	assertTrue(ovr.isPresent());
     	assertEquals("tools-java", ovr.get().getPackage().getName());
@@ -339,7 +339,7 @@ public class ExternalRefParserTest {
     	erp = new ExternalRefParser(er, true);
     	ovr = erp.osvVulnerabilityRequest();
     	assertTrue(ovr.isPresent());
-    	assertEquals("org.spdx.tools-java", ovr.get().getPackage().getName());
+    	assertEquals("org.spdx:tools-java", ovr.get().getPackage().getName());
     	assertEquals("2.2.2", ovr.get().getVersion());
     	assertEquals("pkg:maven/org.spdx/tools-java@2.2.2", ovr.get().getPackage().getPurl());
     	
@@ -349,7 +349,7 @@ public class ExternalRefParserTest {
     	erp = new ExternalRefParser(er, true);
     	ovr = erp.osvVulnerabilityRequest();
     	assertTrue(ovr.isPresent());
-    	assertEquals("org.spdx.tools-java", ovr.get().getPackage().getName());
+    	assertEquals("org.spdx:tools-java", ovr.get().getPackage().getName());
     	assertTrue(ovr.get().getVersion() == null);
     	assertEquals("pkg:maven/org.spdx/tools-java", ovr.get().getPackage().getPurl());
     }


### PR DESCRIPTION
Change the default behavior of the Maven external ref parser to use the organization name in the OSV package name

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>