### PR TITLE
Fix purl maven name

### DIFF
--- a/src/main/java/com/sourceauditor/spdx_to_osv/ExternalRefParser.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/ExternalRefParser.java
@@ -121,6 +121,11 @@ public class ExternalRefParser {
         	this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(version));
         } else if ("docker".equals(type) && Objects.nonNull(version) && version.startsWith("sha256:")) {
         	this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(version.substring("sha256:".length())));
+        } else if ("maven".equals(type) && this.useMavenGroupInPkgName) {
+        	packageName = match.group("namespace").replaceAll("/", ".") + ":" + packageName;
+        	this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
+	        		new OsvPackage(packageName, purlTypeToOsvEcosystem(type), 
+	        				referenceLocator), version));
         } else {
 	        this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
 	        		new OsvPackage(packageName, purlTypeToOsvEcosystem(type), 

--- a/src/test/java/com/sourceauditor/spdx_to_osv/ExternalRefParserTest.java
+++ b/src/test/java/com/sourceauditor/spdx_to_osv/ExternalRefParserTest.java
@@ -222,7 +222,7 @@ public class ExternalRefParserTest {
     	ExternalRef er = spdxPackage.createExternalRef(ReferenceCategory.PACKAGE_MANAGER, 
                 ListedReferenceTypes.getListedReferenceTypes().getListedReferenceTypeByName("purl"), 
                 "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?packaging=sources", null);
-    	ExternalRefParser erp = new ExternalRefParser(er);
+    	ExternalRefParser erp = new ExternalRefParser(er, false);
     	Optional<OsvVulnerabilityRequest> ovr = erp.osvVulnerabilityRequest();
     	assertTrue(ovr.isPresent());
     	assertEquals("batik-anim", ovr.get().getPackage().getName());
@@ -233,7 +233,14 @@ public class ExternalRefParserTest {
         er = spdxPackage.createExternalRef(ReferenceCategory.PACKAGE_MANAGER, 
                 ListedReferenceTypes.getListedReferenceTypes().getListedReferenceTypeByName("purl"), 
                 "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release", null);
-    	erp = new ExternalRefParser(er);
+    	erp = new ExternalRefParser(er, true);
+    	ovr = erp.osvVulnerabilityRequest();
+    	assertTrue(ovr.isPresent());
+    	assertEquals("org.apache.xmlgraphics:batik-anim", ovr.get().getPackage().getName());
+    	assertEquals("1.9.1", ovr.get().getVersion());
+    	assertEquals("pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release", ovr.get().getPackage().getPurl());
+    	assertEquals("Maven", ovr.get().getPackage().getEcosystem());
+    	erp = new ExternalRefParser(er, false);
     	ovr = erp.osvVulnerabilityRequest();
     	assertTrue(ovr.isPresent());
     	assertEquals("batik-anim", ovr.get().getPackage().getName());


### PR DESCRIPTION
Adds in the full namespace to the OSV package name for PURL maven types

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>