### PR TITLE
Add support for dependency tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Produce an Open Source Vulnerability JSON file based on information in an SPDX document
 
 ## Usage
-java -jar spdx-to-osv-with-dependencies.jar SpdxFile.spdx OSVOutput.json
+`java -jar spdx-to-osv-with-dependencies.jar -I SpdxFile.spdx -O OSVOutput.json`
 
 where SpdxFile.spdx is an SPDX file in one of the following file extensions:
 - .json JSON SPDX format
@@ -11,6 +11,10 @@ where SpdxFile.spdx is an SPDX file in one of the following file extensions:
 - .rdf.xml, .rdf - RDF/XML SPDX format
 - .xlsx, .xls Spreadsheet SPDX format
 
+Optional parameters:
+- `-a`,`--all` Include vulnerabilities for all packages in the SPDX file. Default is to only include vulnerabilities related to the element described by the document.
+-  `-f`,`--inputFormat <arg>`   Input file format - RDFXML, JSON, XLS, XLSX, YAML, or TAG
+
 The utility produces an output file OSVOutput.json in the [OSV JSON format](https://docs.google.com/document/d/1sylBGNooKtf220RHQn1I8pZRmqXZQADDQ_TOABrKTpA/edit)
 
 ## How it Works
@@ -18,3 +22,5 @@ The utility uses the [OSV API's](https://osv.dev/) to query the OSV database usi
 - Package name and version
 - CVE ExternalRef
 - Github download location if it includes a hash or version tag
+
+Only vulnerabilities related to the SPDX element described by the document will be reported unless the `--all` option is used in which case vulnerabilities for all packages in the document will be provided.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sourceauditor</groupId>
   <artifactId>spdx-to-osv</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.3</version>
   <packaging>jar</packaging>
 
   <name>spdx-to-osv</name>
@@ -109,6 +109,11 @@
     	<groupId>us.springett</groupId>
     	<artifactId>cpe-parser</artifactId>
     	<version>2.0.2</version>
+    </dependency>
+    <dependency>
+    	<groupId>commons-cli</groupId>
+    	<artifactId>commons-cli</artifactId>
+    	<version>1.5.0</version>
     </dependency>
   </dependencies>
     <build>

--- a/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
@@ -12,18 +12,34 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.spdx.library.InvalidSPDXAnalysisException;
+import org.spdx.library.SpdxConstants;
 import org.spdx.library.model.ExternalRef;
+import org.spdx.library.model.Relationship;
+import org.spdx.library.model.SpdxDocument;
+import org.spdx.library.model.SpdxElement;
+import org.spdx.library.model.SpdxFile;
 import org.spdx.library.model.SpdxModelFactory;
 import org.spdx.library.model.SpdxPackage;
+import org.spdx.library.model.enumerations.RelationshipType;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.ISerializableModelStore;
-import org.spdx.tools.InvalidFileNameException;
 import org.spdx.tools.SpdxToolsHelper;
 import org.spdx.tools.SpdxToolsHelper.SerFileType;
 
@@ -47,39 +63,173 @@ public class Main {
     
     static final int ERROR_STATUS = 1;
     static final int SUCCESS_STATUS = 0;
+    
+    /**
+     * Forward relationships that may cause a security vulnerability 
+     * (e.g. A depends_on B.  B has a vulnerability.  A may have a vulnerability)
+     */
+    static final Set<RelationshipType> RELEVANT_RELATIONSHIPS = new HashSet<>();
+    /**
+     * Reverse relationships that may cause a security vulnerability 
+     * (e.g. A is_a_dependency_of B.  A has a vulnerability.  B may have a vulnerability)
+     */
+    static final Set<RelationshipType> RELEVANT_REVERSE_RELATIONSHIPS = new HashSet<>();
+    /**
+     * Relationships which do not impact the security of either side of the relationship
+     */
+    static final Set<RelationshipType> NON_RELEVANT_RELATIONSHIPS = new HashSet<>();
+    
+    static {
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.CONTAINS);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.COPY_OF);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.DYNAMIC_LINK);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.EXPANDED_FROM_ARCHIVE);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.FILE_ADDED);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.GENERATED_FROM);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.GENERATED_FROM);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.PACKAGE_OF);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.PATCH_FOR);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.STATIC_LINK);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.HAS_PREREQUISITE);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.VARIANT_OF);
+    	RELEVANT_RELATIONSHIPS.add(RelationshipType.DEPENDS_ON);
+    	
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.CONTAINED_BY);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.COPY_OF);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.DISTRIBUTION_ARTIFACT);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.GENERATES);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.OPTIONAL_COMPONENT_OF);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.PACKAGE_OF);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.PATCH_APPLIED);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.PREREQUISITE_FOR);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.VARIANT_OF);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.DEPENDENCY_OF);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.OPTIONAL_DEPENDENCY_OF);
+    	RELEVANT_REVERSE_RELATIONSHIPS.add(RelationshipType.RUNTIME_DEPENDENCY_OF);
+    	
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DESCRIBES);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DESCRIBED_BY);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.ANCESTOR_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.BUILD_TOOL_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DATA_FILE_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DESCENDANT_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DOCUMENTATION_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.FILE_DELETED);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.FILE_MODIFIED);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.METAFILE_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.OTHER);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.AMENDS);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.TEST_CASE_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.MISSING);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.BUILD_DEPENDENCY_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DEPENDENCY_MANIFEST_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DEV_DEPENDENCY_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.DEV_TOOL_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.EXAMPLE_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.PROVIDED_DEPENDENCY_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.TEST_DEPENDENCY_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.TEST_OF);
+    	NON_RELEVANT_RELATIONSHIPS.add(RelationshipType.TEST_TOOL_OF);
+    }
+    
 
     /**
      * @param args args[0] input SPDX file, args[1] output OSV JSON file
      */
     public static void main(String[] args) {
-        if (args.length != 2) {
-            System.err.println("Invalid number of arguments.");
-            usage();
+		Options options = createOptions();
+		if (args.length == 1 && "-h".equals(args[0])) {
+			usage(options);
+			System.exit(0);
+		}
+		CommandLineParser parser = new DefaultParser();
+		CommandLine cmdLine = null;
+		try {
+			cmdLine = parser.parse(options, args);
+		} catch (ParseException e1) {
+			System.out.println(e1.getMessage());
+			usage(options);
+			System.exit(ERROR_STATUS);
+		}
+        File fromFile = new File(cmdLine.getOptionValue("I").trim());
+        File toFile = new File(cmdLine.getOptionValue("O").trim());
+        SerFileType inputFileType = null;
+        if (cmdLine.hasOption("f")) {
+        	try {
+                inputFileType = SpdxToolsHelper.strToFileType(cmdLine.getOptionValue("f").trim());
+            } catch (Exception e) {
+                System.out.println("Invalid file type "+cmdLine.getOptionValue("f").trim() + 
+                		".  Expecting RDFXML, JSON, XLS, XLSX, YAML, or TAG");
+                System.exit(ERROR_STATUS);
+            }
+        }
+        try {
+            inputFileType = SpdxToolsHelper.fileToFileType(fromFile);
+        } catch (Exception e) {
+            System.out.println("Invalid file extension for input file "+fromFile.getName());
             System.exit(ERROR_STATUS);
         }
-        File fromFile = new File(args[0]);
-        File toFile = new File(args[1]);
+        boolean allPackages = cmdLine.hasOption("a");
         try {
-            spdxToOsv(fromFile, toFile);
+            spdxToOsv(fromFile, toFile, inputFileType, allPackages);
             System.exit(SUCCESS_STATUS);
         } catch(Exception ex) {
             System.err.println("Error converting SPDX file to OSV.");
             if (Objects.nonNull(ex.getMessage())) {
                 System.err.println(ex.getMessage());
             }
-            usage();
+            usage(options);
             System.exit(ERROR_STATUS);
         }
     }
     
     /**
+	 * @return Options for the spdx-to-osv comand
+	 */
+	private static Options createOptions() {
+		Options retval = new Options();
+		retval.addOption(Option.builder("I")
+				.longOpt("input")
+				.desc("Input SPDX file in one of the supported formats (json, yaml, tag/value, xls, xlsx, rdf/xml)")
+				.hasArg(true)
+				.required(true)
+				.build()
+				);
+		retval.addOption(Option.builder("O")
+				.longOpt("output")
+				.desc("output file name.  File will be in the OSV JSON format")
+				.hasArg(true)
+				.required(true)
+				.build()
+				);
+		retval.addOption(Option.builder("f")
+				.longOpt("inputFormat")
+				.desc("Input file format - RDFXML, JSON, XLS, XLSX, YAML, or TAG")
+				.hasArg(true)
+				.required(false)
+				.build()
+				);
+		retval.addOption(Option.builder("a")
+				.longOpt("all")
+				.desc("Include vulnerabilities for all packages in the SPDX file. "
+						+ "Default is to only include vulnerabilities related to the element described by the document.")
+				.hasArg(false)
+				.required(false)
+				.build()
+				);
+		return retval;
+	}
+
+	/**
      * Produce an OSV Output File from an SPDX input file
      * @param fromFile SPDX input file
      * @param toFile OSV output file
+     * @param inputFileType Input file type for the SPDX file
+     * @param allPackage if true, scan all packages in the document
      * @throws SpdxToOsvException 
      * @throws IOException 
      */
-    public static void spdxToOsv(File fromFile, File toFile) throws SpdxToOsvException, IOException {
+    public static void spdxToOsv(File fromFile, File toFile, SerFileType inputFileType, boolean allPackages) throws SpdxToOsvException, IOException {
         if (!fromFile.exists()) {
             throw new SpdxToOsvException("Input file "+fromFile.getName()+" does not exist");
         }
@@ -89,15 +239,9 @@ public class Main {
         InputStream inStream = null;
         Writer writer = null;
         try {
-            SerFileType inputFileType = null;
-            try {
-                inputFileType = SpdxToolsHelper.fileToFileType(fromFile);
-            } catch (InvalidFileNameException e) {
-                throw new SpdxToOsvException("Invalid file extension for input file "+fromFile.getName());
-            }
             writer = new OutputStreamWriter(new FileOutputStream(toFile), StandardCharsets.UTF_8);
             inStream = new FileInputStream(fromFile);
-            spdxToOsv(inStream, inputFileType, writer);
+            spdxToOsv(inStream, inputFileType, writer, allPackages);
         } finally {
             if (Objects.nonNull(inStream)) {
                 inStream.close();
@@ -113,17 +257,18 @@ public class Main {
      * @param fromStore Model store containing the SPDX model
      * @param documentUri Document URI for the document to use
      * @param writer writer the OSV file
+     * @param allPackage if true, scan all packages in the document
      * @throws SpdxToOsvException
      * @throws IOException 
      * @throws InvalidSPDXAnalysisException 
      */
-    public static void spdxToOsv(IModelStore fromStore, String documentUri, Writer writer) throws SpdxToOsvException, IOException, InvalidSPDXAnalysisException {
+    public static void spdxToOsv(IModelStore fromStore, String documentUri, Writer writer, boolean allPackages) throws SpdxToOsvException, IOException, InvalidSPDXAnalysisException {
     	OsvApi osvApi = OsvApi.getInstance();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         Set<OsvVulnerabilityRequest> pvSet = new HashSet<>();
-        SpdxModelFactory.getElements(fromStore, documentUri, null, SpdxPackage.class).forEach(oPackage -> {
+        List<SpdxPackage> pkgs = getPackageFromDocument(fromStore, documentUri, allPackages);
+        for (SpdxPackage pkg:pkgs) {
             try {
-                SpdxPackage pkg = (SpdxPackage)oPackage;
                 Optional<String> packageName = pkg.getName();
                 Optional<String> version = pkg.getVersionInfo();
                 if (packageName.isPresent() && version.isPresent()) {
@@ -155,7 +300,7 @@ public class Main {
             } catch (InvalidSPDXAnalysisException ex) {
                 throw new RuntimeException(ex);
             }
-        });
+        }
         // call the API on all the package name versions
         writer.append('[');
         int numVulns = 0;
@@ -173,17 +318,142 @@ public class Main {
     }
 
     /**
+     * @param fromStore Model store containing the SPDX model
+     * @param documentUri Document URI for the document to use
+	 * @param allPackages if true, scan all packages in the document
+	 * @return list of packages to be examined based on the allPackages paramater and dependencies of any documentDescribes element
+     * @throws InvalidSPDXAnalysisException 
+	 */
+	private static List<SpdxPackage> getPackageFromDocument(
+			IModelStore fromStore, String documentUri, boolean allPackages) throws InvalidSPDXAnalysisException {
+		if (allPackages) {
+			List<SpdxPackage> retval = new ArrayList<>();
+			SpdxModelFactory.getElements(fromStore, documentUri, null, SpdxPackage.class).forEach(oPackage -> {
+	                retval.add((SpdxPackage)oPackage);
+			});
+			return retval;
+		} else {
+			SpdxDocument doc = (SpdxDocument)(SpdxModelFactory.getModelObject(fromStore, documentUri, SpdxConstants.SPDX_DOCUMENT_ID, 
+					SpdxConstants.CLASS_SPDX_DOCUMENT, null, false));
+			if (Objects.isNull(doc)) {
+				throw new InvalidSPDXAnalysisException("Missing document ID");
+			}
+			Map<String, List<Relationship>> fromElementIdRelationshipMap = new HashMap<>();
+			Map<String, List<SpdxElement>> toElementIdToRelationship = new HashMap<>();
+			// Collect all the relationships from Files and Packages that have a relevant relationship type
+			SpdxModelFactory.getElements(fromStore, documentUri, null, SpdxPackage.class).forEach(oPackage -> {
+				try {
+					addRelevantRelationships((SpdxElement)oPackage, fromElementIdRelationshipMap, 
+							toElementIdToRelationship);
+				} catch (InvalidSPDXAnalysisException e) {
+					throw new RuntimeException("Error parsing relationship graph",e);
+				}
+			});
+			SpdxModelFactory.getElements(fromStore, documentUri, null, SpdxFile.class).forEach(oFile -> {
+				try {
+					addRelevantRelationships((SpdxElement)oFile, fromElementIdRelationshipMap, 
+							toElementIdToRelationship);
+				} catch (InvalidSPDXAnalysisException e) {
+					throw new RuntimeException("Error parsing relationship graph",e);
+				}
+			});
+			List<SpdxPackage> retval = new ArrayList<>();
+			Set<String> visitedElementIds = new HashSet<>();
+			for (SpdxElement described:doc.getDocumentDescribes()) {
+				if (!visitedElementIds.contains(described.getId())) {
+					collectRelevantPackages(described, retval, 
+							fromElementIdRelationshipMap, toElementIdToRelationship,
+							visitedElementIds);
+				}
+			}
+			return retval;
+		}
+	}
+
+	/**
+	 * Collects all of relevant packages related to element
+	 * @param element element to search for relevant relationship
+	 * @param relevantPackages result of packages which are added to
+	 * @param toElementIdToRelationship map of element ID's to relevant relationships
+	 * @param fromElementIdRelationshipMap map of from element ID's to the element containing the relevant relationship
+	 * @param visitedElementIds Set of all element ID's visited by the collector - used to avoid infinite recursion
+	 * @throws InvalidSPDXAnalysisException 
+	 */
+	private static void collectRelevantPackages(SpdxElement element, 
+			List<SpdxPackage> relevantPackages, 
+			Map<String, List<Relationship>> fromElementIdRelationshipMap, 
+			Map<String, List<SpdxElement>> toElementIdToRelationship, 
+			Set<String> visitedElementIds) throws InvalidSPDXAnalysisException {
+		String id = element.getId();
+		if (visitedElementIds.contains(id)) {
+			return;
+		}
+		visitedElementIds.add(id);
+		if (element instanceof SpdxPackage) {
+			// if we're here, we're relevant!
+			relevantPackages.add((SpdxPackage)element);
+		}
+		if (fromElementIdRelationshipMap.containsKey(id)) {
+			for (Relationship relationship:fromElementIdRelationshipMap.get(id)) {
+				if (relationship.getRelatedSpdxElement().isPresent()) {
+					collectRelevantPackages(relationship.getRelatedSpdxElement().get(),
+							relevantPackages, fromElementIdRelationshipMap,
+							toElementIdToRelationship, visitedElementIds);
+				}
+			}
+		}
+		if (toElementIdToRelationship.containsKey(id)) {
+			for (SpdxElement relatedElement:toElementIdToRelationship.get(id)) {
+				collectRelevantPackages(relatedElement, relevantPackages, 
+						fromElementIdRelationshipMap,
+						toElementIdToRelationship, visitedElementIds);
+			}
+		}
+	}
+
+	/**
+	 * Add relationships from the element to the relationship maps collecting any relationship
+	 * considered relevant to possible security violations (e.g. development and test relationships would
+	 * be excluded)
+	 * @param element Element containing the relationships
+	 * @param fromElementIdRelationshipMap Map from an element ID to all of it's relevant relationships 
+	 * @param toElementIdRelationshipMap
+	 * @throws InvalidSPDXAnalysisException 
+	 */
+	private static void addRelevantRelationships(SpdxElement element,
+			Map<String, List<Relationship>> fromElementIdRelationshipMap,
+			Map<String, List<SpdxElement>> toElementIdRelationshipMap) throws InvalidSPDXAnalysisException {
+		List<Relationship> elementRelationships = new ArrayList<>();
+		fromElementIdRelationshipMap.put(element.getId(), elementRelationships);
+		for (Relationship relationship:element.getRelationships()) {
+			if (RELEVANT_RELATIONSHIPS.contains(relationship.getRelationshipType())) {
+				elementRelationships.add(relationship);
+			}
+			if (RELEVANT_REVERSE_RELATIONSHIPS.contains(relationship.getRelationshipType()) &&
+					relationship.getRelatedSpdxElement().isPresent()) {
+				List<SpdxElement> reverseRelationships = toElementIdRelationshipMap.get(relationship.getRelatedSpdxElement().get().getId());
+				if (Objects.isNull(reverseRelationships)) {
+					reverseRelationships = new ArrayList<>();
+					toElementIdRelationshipMap.put(relationship.getRelatedSpdxElement().get().getId(), reverseRelationships);
+				}
+				reverseRelationships.add(element);
+			}
+		}
+	}
+
+	/**
      * Writes OSV JSON data to the outStream based on an SPDX input stream
      * @param inStream Stream for the SPDX file
      * @param inputFileType Serialization type for the input file stream
      * @param writer writer the OSV file
+     * @param allPackage if true, scan all packages in the document
      * @throws SpdxToOsvException 
      */
-    public static void spdxToOsv(InputStream inStream, SerFileType inputFileType, Writer writer) throws SpdxToOsvException {
+    public static void spdxToOsv(InputStream inStream, SerFileType inputFileType, Writer writer, boolean allPackages) throws SpdxToOsvException {
         try {
             ISerializableModelStore fromStore = SpdxToolsHelper.fileTypeToStore(inputFileType);
             String documentUri = fromStore.deSerialize(inStream, false);
-            spdxToOsv(fromStore, documentUri, writer);
+            spdxToOsv(fromStore, documentUri, writer, allPackages);
         } catch (InvalidSPDXAnalysisException e) {
             throw new SpdxToOsvException("Error reading the SPDX input file",e);
         } catch (IOException e) {
@@ -191,15 +461,12 @@ public class Main {
         }
     }
 
-    private static void usage() {
-        System.out.println("-jar spdx-to-osv-with-dependencies.jar SpdxFile.spdx OSVOutput.json");
-        System.out.println();
-        System.out.println("where SpdxFile.spdx is an SPDX file in one of the following file extensions:");
-        System.out.println("- .json JSON SPDX format");
-        System.out.println("- .yaml YAML SPDX format");
-        System.out.println("- .spdx Tag/Value SPDX format");
-        System.out.println("- .rdf.xml, .rdf - RDF/XML SPDX format");
-        System.out.println("- .xlsx, .xls Spreadsheet SPDX format");
-    }
+	/**
+	 * Print usage
+	 */
+	private static void usage(Options options) {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.printHelp("spdx-to-osv", options);
+	}
 
 }

--- a/src/test/java/com/sourceauditor/spdx_to_osv/OsvToSpdxTest.java
+++ b/src/test/java/com/sourceauditor/spdx_to_osv/OsvToSpdxTest.java
@@ -30,6 +30,7 @@ import org.spdx.library.model.license.SpdxNoAssertionLicense;
 import org.spdx.library.referencetype.ListedReferenceTypes;
 import org.spdx.storage.IModelStore.IdType;
 import org.spdx.storage.simple.InMemSpdxStore;
+import org.spdx.tools.SpdxToolsHelper.SerFileType;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -81,7 +82,7 @@ public class OsvToSpdxTest {
 		Relationship describesRelationship = doc.createRelationship(tinymcePackage, RelationshipType.DESCRIBES, null);
 		doc.addRelationship(describesRelationship);
 		StringWriter writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		String resultStr = writer.toString();
 		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -105,7 +106,7 @@ public class OsvToSpdxTest {
 		Relationship describesRelationship = doc.createRelationship(jinjaPackage, RelationshipType.DESCRIBES, null);
 		doc.addRelationship(describesRelationship);
 		StringWriter writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		String resultStr = writer.toString();
 		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -131,7 +132,7 @@ public class OsvToSpdxTest {
 		Relationship describesRelationship = doc.createRelationship(xlsxPackage, RelationshipType.DESCRIBES, null);
 		doc.addRelationship(describesRelationship);
 		StringWriter writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		String resultStr = writer.toString();
 		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -157,7 +158,7 @@ public class OsvToSpdxTest {
 		Relationship describesRelationship = doc.createRelationship(xlsxPackage, RelationshipType.DESCRIBES, null);
 		doc.addRelationship(describesRelationship);
 		StringWriter writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		String resultStr = writer.toString();
 		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -183,7 +184,7 @@ public class OsvToSpdxTest {
 		Relationship describesRelationship = doc.createRelationship(tinymcePackage, RelationshipType.DESCRIBES, null);
 		doc.addRelationship(describesRelationship);
 		StringWriter writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		String resultStr = writer.toString();
 		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 		List<OsvVulnerability> singleResult = gson.fromJson(resultStr, listType);
@@ -195,7 +196,7 @@ public class OsvToSpdxTest {
         String downloadLocation = "https://www.npmjs.com/package/tinymce/v/4.9.11";
         tinymcePackage.setDownloadLocation(downloadLocation);
         writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		resultStr = writer.toString();
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
 		assertEquals(singleResult.size(), result.size());
@@ -207,7 +208,7 @@ public class OsvToSpdxTest {
 		Path outputDir = Files.createTempDirectory("osv-to-spdx-test");
 		File outputFile = outputDir.resolve("output.json").toFile();
 		try {
-			Main.spdxToOsv(spdxFile, outputFile);
+			Main.spdxToOsv(spdxFile, outputFile, SerFileType.JSON, true);
 			String resultStr = Files.readString(outputFile.toPath());
 			Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 			List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -244,7 +245,7 @@ public class OsvToSpdxTest {
 		Path outputDir = Files.createTempDirectory("osv-to-spdx-test");
 		File outputFile = outputDir.resolve("output.json").toFile();
 		try {
-			Main.spdxToOsv(spdxFile, outputFile);
+			Main.spdxToOsv(spdxFile, outputFile, SerFileType.TAG, true);
 			String resultStr = Files.readString(outputFile.toPath());
 			Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 			List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -281,7 +282,7 @@ public class OsvToSpdxTest {
 		Path outputDir = Files.createTempDirectory("osv-to-spdx-test");
 		File outputFile = outputDir.resolve("output.json").toFile();
 		try {
-			Main.spdxToOsv(spdxFile, outputFile);
+			Main.spdxToOsv(spdxFile, outputFile, SerFileType.RDFXML, true);
 			String resultStr = Files.readString(outputFile.toPath());
 			Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 			List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -318,7 +319,7 @@ public class OsvToSpdxTest {
 		Path outputDir = Files.createTempDirectory("osv-to-spdx-test");
 		File outputFile = outputDir.resolve("output.json").toFile();
 		try {
-			Main.spdxToOsv(spdxFile, outputFile);
+			Main.spdxToOsv(spdxFile, outputFile, SerFileType.XLSX, true);
 			String resultStr = Files.readString(outputFile.toPath());
 			Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 			List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
@@ -349,6 +350,97 @@ public class OsvToSpdxTest {
 		}
 	}
 	
+	
+	@Test
+	public void testPackageDependenciesForward() throws InvalidSPDXAnalysisException, SpdxToOsvException, IOException {
+		InMemSpdxStore modelStore = new InMemSpdxStore();
+		ModelCopyManager copyManager = new ModelCopyManager();
+		String documentUri = "https://org.spdx.documents/this/is/a/test";
+		SpdxDocument doc = SpdxModelFactory.createSpdxDocument(modelStore, documentUri, copyManager);
+		ExternalRef externalRef = doc.createExternalRef(ReferenceCategory.PACKAGE_MANAGER, 
+				ListedReferenceTypes.getListedReferenceTypes().getListedReferenceTypeByName("maven-central"), 
+				"org.webjars.npm:xlsx:0.16.6", null);
+		SpdxPackage xlsxPackage = doc.createPackage(modelStore.getNextId(IdType.SpdxId, documentUri), 
+				"xlsx", new SpdxNoAssertionLicense(), "NOASSERTION", new SpdxNoAssertionLicense())
+				.setFilesAnalyzed(false)
+				.addExternalRef(externalRef)
+				.build();
+		String downloadLocation = "https://github.com/pallets/jinja/tree/6879efc2c1596d11a6a6ad296f80063b558d5e0f";
+		SpdxPackage jinjaPackage = doc.createPackage(modelStore.getNextId(IdType.SpdxId, documentUri), 
+				"Jinja", new SpdxNoAssertionLicense(), "NOASSERTION", new SpdxNoAssertionLicense())
+				.setDownloadLocation(downloadLocation)
+				.setFilesAnalyzed(false)
+				.build();
+		SpdxPackage mainPackage = doc.createPackage(modelStore.getNextId(IdType.SpdxId, documentUri), 
+				"main", new SpdxNoAssertionLicense(), "NOASSERTION", new SpdxNoAssertionLicense())
+				.setFilesAnalyzed(false)
+				.build();
+		Relationship describesRelationship = doc.createRelationship(mainPackage, RelationshipType.DESCRIBES, null);
+		doc.addRelationship(describesRelationship);
+		Relationship buildTool = mainPackage.createRelationship(jinjaPackage, RelationshipType.BUILD_TOOL_OF, "");
+		mainPackage.addRelationship(buildTool);
+		Relationship dynamic = mainPackage.createRelationship(xlsxPackage, RelationshipType.DYNAMIC_LINK, "");
+		mainPackage.addRelationship(dynamic);
+		StringWriter writer = new StringWriter();
+		Main.spdxToOsv(modelStore, documentUri, writer, false);
+		String resultStr = writer.toString();
+		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
+		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
+		assertTrue(result.size() > 0);
+		assertTrue(result.get(0).getAffected().size() > 0);
+        assertEquals("org.webjars.npm:xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
+        writer = new StringWriter();
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
+		resultStr = writer.toString();
+		List<OsvVulnerability> result2 = gson.fromJson(resultStr, listType);
+		assertTrue(result2.size() > result.size());
+	}
+	
+	@Test
+	public void testPackageDependenciesReverse() throws InvalidSPDXAnalysisException, SpdxToOsvException, IOException {
+		InMemSpdxStore modelStore = new InMemSpdxStore();
+		ModelCopyManager copyManager = new ModelCopyManager();
+		String documentUri = "https://org.spdx.documents/this/is/a/test";
+		SpdxDocument doc = SpdxModelFactory.createSpdxDocument(modelStore, documentUri, copyManager);
+		ExternalRef externalRef = doc.createExternalRef(ReferenceCategory.PACKAGE_MANAGER, 
+				ListedReferenceTypes.getListedReferenceTypes().getListedReferenceTypeByName("maven-central"), 
+				"org.webjars.npm:xlsx:0.16.6", null);
+		SpdxPackage xlsxPackage = doc.createPackage(modelStore.getNextId(IdType.SpdxId, documentUri), 
+				"xlsx", new SpdxNoAssertionLicense(), "NOASSERTION", new SpdxNoAssertionLicense())
+				.setFilesAnalyzed(false)
+				.addExternalRef(externalRef)
+				.build();
+		String downloadLocation = "https://github.com/pallets/jinja/tree/6879efc2c1596d11a6a6ad296f80063b558d5e0f";
+		SpdxPackage jinjaPackage = doc.createPackage(modelStore.getNextId(IdType.SpdxId, documentUri), 
+				"Jinja", new SpdxNoAssertionLicense(), "NOASSERTION", new SpdxNoAssertionLicense())
+				.setDownloadLocation(downloadLocation)
+				.setFilesAnalyzed(false)
+				.build();
+		SpdxPackage mainPackage = doc.createPackage(modelStore.getNextId(IdType.SpdxId, documentUri), 
+				"main", new SpdxNoAssertionLicense(), "NOASSERTION", new SpdxNoAssertionLicense())
+				.setFilesAnalyzed(false)
+				.build();
+		Relationship describesRelationship = doc.createRelationship(mainPackage, RelationshipType.DESCRIBES, null);
+		doc.addRelationship(describesRelationship);
+		Relationship buildTool = mainPackage.createRelationship(jinjaPackage, RelationshipType.BUILD_TOOL_OF, "");
+		mainPackage.addRelationship(buildTool);
+		Relationship generates = mainPackage.createRelationship(mainPackage, RelationshipType.GENERATES, "");
+		xlsxPackage.addRelationship(generates);
+		StringWriter writer = new StringWriter();
+		Main.spdxToOsv(modelStore, documentUri, writer, false);
+		String resultStr = writer.toString();
+		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
+		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
+		assertTrue(result.size() > 0);
+		assertTrue(result.get(0).getAffected().size() > 0);
+        assertEquals("org.webjars.npm:xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
+        writer = new StringWriter();
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
+		resultStr = writer.toString();
+		List<OsvVulnerability> result2 = gson.fromJson(resultStr, listType);
+		assertTrue(result2.size() > result.size());
+	}
+	
 	@Test
 	public void testNpmExternalRefLog4j() throws InvalidSPDXAnalysisException, SpdxToOsvException, IOException {
 		InMemSpdxStore modelStore = new InMemSpdxStore();
@@ -366,7 +458,7 @@ public class OsvToSpdxTest {
 		Relationship describesRelationship = doc.createRelationship(log4jPackage, RelationshipType.DESCRIBES, null);
 		doc.addRelationship(describesRelationship);
 		StringWriter writer = new StringWriter();
-		Main.spdxToOsv(modelStore, documentUri, writer);
+		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		String resultStr = writer.toString();
 		Type listType = new TypeToken<List<OsvVulnerability>>(){}.getType();
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);


### PR DESCRIPTION
Changed UI to allow for a -a/--all option for previous behaviour
examining all packages in the spdx file.  Default behaviour only reports
vulnerabilities associated with depdencies on the document describes
elements.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>