### PR TITLE
Change return type for OSV Vulnerability from string to JSON Array

### DIFF
--- a/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvVulnerability.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvVulnerability.java
@@ -6,6 +6,7 @@ package com.sourceauditor.spdx_to_osv.osvmodel;
 
 import java.util.List;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
@@ -88,7 +89,7 @@ public class OsvVulnerability {
      * Enum: "NONE" "LOW" "MEDIUM" "HIGH" "CRITICAL" Deprecated and will be removed in the future.
      */
     @Deprecated
-    String severity;
+    JsonArray severity;
     
     /**
      * Optional. JSON object holding additional information about the vulnerability 
@@ -282,14 +283,14 @@ public class OsvVulnerability {
     /**
      * @return the severity
      */
-    public String getSeverity() {
+    public JsonArray getSeverity() {
         return severity;
     }
 
     /**
      * @param severity the severity to set
      */
-    public void setSeverity(String severity) {
+    public void setSeverity(JsonArray severity) {
         this.severity = severity;
     }
 

--- a/src/test/java/com/sourceauditor/spdx_to_osv/OsvToSpdxTest.java
+++ b/src/test/java/com/sourceauditor/spdx_to_osv/OsvToSpdxTest.java
@@ -138,7 +138,7 @@ public class OsvToSpdxTest {
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
 		assertTrue(result.size() > 0);
 		assertTrue(result.get(0).getAffected().size() > 0);
-        assertEquals("org.webjars.npm:xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
+        assertEquals("xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
 	}
 	
 	@Test
@@ -164,7 +164,7 @@ public class OsvToSpdxTest {
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
 		assertTrue(result.size() > 0);
 		assertTrue(result.get(0).getAffected().size() > 0);
-        assertEquals("org.webjars.npm:xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
+        assertEquals("xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
 	}
 	
 	@Test
@@ -388,7 +388,7 @@ public class OsvToSpdxTest {
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
 		assertTrue(result.size() > 0);
 		assertTrue(result.get(0).getAffected().size() > 0);
-        assertEquals("org.webjars.npm:xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
+        assertEquals("xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
         writer = new StringWriter();
 		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		resultStr = writer.toString();
@@ -433,7 +433,7 @@ public class OsvToSpdxTest {
 		List<OsvVulnerability> result = gson.fromJson(resultStr, listType);
 		assertTrue(result.size() > 0);
 		assertTrue(result.get(0).getAffected().size() > 0);
-        assertEquals("org.webjars.npm:xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
+        assertEquals("xlsx", result.get(0).getAffected().get(0).getOsvPackage().getName());
         writer = new StringWriter();
 		Main.spdxToOsv(modelStore, documentUri, writer, true);
 		resultStr = writer.toString();


### PR DESCRIPTION
This fixes a problem introduced by a change in OSV where it is now
returning an array of priority objects rather than a single enumeration.

Although the OSV documentation states the "severity" property is an enumeration and it previously returned a string, it is now returning the following for one of the vulnerabilities:

```
"severity":[{"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}]},{"id":"PYSEC-2014-8","details":"The default configuration for bccache.FileSystemBytecodeCache in Jinja2 before 2.7.2 does not properly create temporary files, which allows local users to gain privileges via a crafted .cache file with a name starting with __jinja2_ in /tmp.","aliases":["CVE-2014-1402"]
```

This may be a bug in the OSV code, but to pass the unit tests, we will now check for an array.

Note that the severity field is not currently used by spdx-to-osv.

The unit tests are also updated to check for a product name "xlsx" which
is now being return from OSV (previously it was returning
"org.webjars.npm:xlsx".

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>