### PR TITLE
Fix 400 in OSV query when using github download locator

### DIFF
--- a/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
@@ -294,7 +294,11 @@ public class Main {
                 if (downloadLocation.isPresent()) {
                     Optional<OsvVulnerabilityRequest> pnv = new DownloadLocationParser(downloadLocation.get()).getOsvVulnerabilityRequest();
                     if (pnv.isPresent()) {
-                        pvSet.add(pnv.get());
+                        OsvVulnerabilityRequest req = pnv.get();
+                        if (req.getVersion() == null && req.getCommit() == null && version.isPresent()) {
+                            req.setVersion(version.get());
+                        }
+                        pvSet.add(req);
                     }
                 }
             } catch (InvalidSPDXAnalysisException ex) {


### PR DESCRIPTION
When using the download github locator flow, the OSV request is initialized with the `null` version. This PR introduces a fix that will fill up the OSV request with a version if available in the `PackageVersion` field.

This results in an error with the following stack trace
```
Error converting SPDX file to OSV.
I/O error converting SPDX to OSV
com.sourceauditor.spdx_to_osv.SpdxToOsvException: I/O error converting SPDX to OSV
at com.sourceauditor.spdx_to_osv.Main.spdxToOsv(Main.java:461)
at com.sourceauditor.spdx_to_osv.Main.spdxToOsv(Main.java:245)
at com.sourceauditor.spdx_to_osv.Main.main(Main.java:174)
Caused by: java.io.IOException: Server returned HTTP response code: 400 for URL: https://api.osv.dev/v1/query
at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1997)
at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1589)
at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:224)
at com.sourceauditor.spdx_to_osv.OsvApi.queryVulnerabilities(OsvApi.java:80)
at com.sourceauditor.spdx_to_osv.Main.spdxToOsv(Main.java:309)
at com.sourceauditor.spdx_to_osv.Main.spdxToOsv(Main.java:457)
```

This error can be fixed by populating the `version` field:

```
➜  / curl --location --request POST 'https://api.osv.dev/v1/query' \
--header 'Content-Type: text/plain' \
--data-raw '{
  "package": {
    "name": "heketi",
    "ecosystem": "OSS-Fuzz",
    "purl": "pkg:github/heketi/heketi"
  }
}'
{"code":3,"message":"Invalid query."}%
➜  / curl --location --request POST 'https://api.osv.dev/v1/query' \
--header 'Content-Type: text/plain' \
--data-raw '{
  "version": "v10.3.0",
  "package": {
    "name": "heketi",
    "ecosystem": "OSS-Fuzz",
    "purl": "pkg:github/heketi/heketi"
  }
}'
{}%
```

In addition, this will need resolution on what to do with this bug as well:

https://github.com/goneall/spdx-to-osv/blob/main/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvVulnerabilityRequest.java#L44


Signed-off-by: Brandon Lum <lumjjb@gmail.com>