### PR TITLE
Edit parsing to support golang bom tool output

### DIFF
--- a/src/main/java/com/sourceauditor/spdx_to_osv/DownloadLocationParser.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/DownloadLocationParser.java
@@ -67,14 +67,16 @@ public class DownloadLocationParser {
 	private void parseGithub() {
 		String ecosystem = "OSS-Fuzz";
 		String purlPrefix = "pkg:github/";
+		String githubNamePrefix = "github.com/";
 		
 		Matcher matcher = GITHUB_HTTPS_PATTERN.matcher(this.downloadLocation);
 		//NOTE: This match must be done before GITHUB_PAGE_PATTERN since it will also match
 		if (matcher.matches()) {
 			String org = matcher.group(1);
 			String pkg = matcher.group(2);
+
 			this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
-					new OsvPackage(pkg, ecosystem, purlPrefix + org + "/" + pkg), null));
+					new OsvPackage(githubNamePrefix + org + "/" + pkg, null, null), null));
 			return;
 		}
 		
@@ -83,7 +85,7 @@ public class DownloadLocationParser {
 			String org = matcher.group(1);
 			String pkg = matcher.group(2);
 			this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
-					new OsvPackage(pkg, ecosystem, purlPrefix + org + "/" + pkg), null));
+					new OsvPackage(githubNamePrefix + org + "/" + pkg, null, null), null));
 			return;
 		}
 		
@@ -92,7 +94,7 @@ public class DownloadLocationParser {
 			String org = matcher.group(1);
 			String pkg = matcher.group(2);
 			this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
-					new OsvPackage(pkg, ecosystem, purlPrefix + org + "/" + pkg), null));
+					new OsvPackage(githubNamePrefix + org + "/" + pkg, null, null), null));
 			return;
 		}
 		

--- a/src/main/java/com/sourceauditor/spdx_to_osv/DownloadLocationParser.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/DownloadLocationParser.java
@@ -112,7 +112,7 @@ public class DownloadLocationParser {
 			String pkg = matcher.group(2);
 			String version = matcher.group(3);
 			this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
-					new OsvPackage(pkg, ecosystem, purlPrefix + org + "/" + pkg + "@" + version), version));
+					new OsvPackage(githubNamePrefix + org + "/" + pkg, null, null), version));
 			return;
 		}
 		
@@ -122,7 +122,7 @@ public class DownloadLocationParser {
 			String pkg = matcher.group(2);
 			String version = matcher.group(3);
 			this.osvVulnerabilityRequest = Optional.of(new OsvVulnerabilityRequest(
-					new OsvPackage(pkg, ecosystem, purlPrefix + org + "/" + pkg + "@" + version), version));
+					new OsvPackage(githubNamePrefix + org + "/" + pkg, null, null), version));
 			return;
 		}
 	}

--- a/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
@@ -294,7 +294,11 @@ public class Main {
                 if (downloadLocation.isPresent()) {
                     Optional<OsvVulnerabilityRequest> pnv = new DownloadLocationParser(downloadLocation.get()).getOsvVulnerabilityRequest();
                     if (pnv.isPresent()) {
-                        pvSet.add(pnv.get());
+                        OsvVulnerabilityRequest req = pnv.get();
+                        if (req.getVersion() == null && req.getCommit() == null && version.isPresent()) {
+                            req.setVersion(version.get());
+                        }
+                        pvSet.add(req);
                     }
                 }
             } catch (InvalidSPDXAnalysisException ex) {

--- a/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
@@ -272,7 +272,10 @@ public class Main {
                 Optional<String> packageName = pkg.getName();
                 Optional<String> version = pkg.getVersionInfo();
                 if (packageName.isPresent() && version.isPresent()) {
-                    pvSet.add(new OsvVulnerabilityRequest(new OsvPackage(packageName.get(), "OSS-Fuzz", null),
+                    String pName = packageName.get();
+                    // Trim version info at end of name if it exists
+                    pName = pName.split("@")[0];
+                    pvSet.add(new OsvVulnerabilityRequest(new OsvPackage(pName, null, null),
                             version.get()));
                 }
                 for (ExternalRef externalRef:pkg.getExternalRefs()) {
@@ -295,8 +298,12 @@ public class Main {
                     Optional<OsvVulnerabilityRequest> pnv = new DownloadLocationParser(downloadLocation.get()).getOsvVulnerabilityRequest();
                     if (pnv.isPresent()) {
                         OsvVulnerabilityRequest req = pnv.get();
-                        if (req.getVersion() == null && req.getCommit() == null && version.isPresent()) {
-                            req.setVersion(version.get());
+                        if (req.getVersion() == null && req.getCommit() == null) {
+                            if (version.isPresent()) {
+                                req.setVersion(version.get());
+                            } else {
+                                continue;
+                            }
                         }
                         pvSet.add(req);
                     }

--- a/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/Main.java
@@ -273,7 +273,10 @@ public class Main {
                 Optional<String> version = pkg.getVersionInfo();
                 if (packageName.isPresent() && version.isPresent()) {
                     String pName = packageName.get();
-                    // Trim version info at end of name if it exists
+
+                    // Some SPDX documents are created with the package name
+                    // including the versions. Although these should be parsed
+                    // by the creator, this code will workaround the package names.
                     pName = pName.split("@")[0];
                     pvSet.add(new OsvVulnerabilityRequest(new OsvPackage(pName, null, null),
                             version.get()));
@@ -302,6 +305,7 @@ public class Main {
                             if (version.isPresent()) {
                                 req.setVersion(version.get());
                             } else {
+                                System.err.printf("Warning: Unable to query package %s due to missing version/commit info", req.getPackage().getName());
                                 continue;
                             }
                         }
@@ -479,5 +483,8 @@ public class Main {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.printHelp("spdx-to-osv", options);
 	}
+
+
+
 
 }

--- a/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvPackage.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvPackage.java
@@ -52,7 +52,6 @@ public class OsvPackage {
     public OsvPackage(String name, String ecosystem, @Nullable String purl) {
         Objects.requireNonNull(name, "Package name can not be null");
         this.name = name;
-        Objects.requireNonNull(ecosystem, "Ecosystem must not be null");
         this.ecosystem = ecosystem;
         this.purl = purl;
     }

--- a/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvVulnerabilityRequest.java
+++ b/src/main/java/com/sourceauditor/spdx_to_osv/osvmodel/OsvVulnerabilityRequest.java
@@ -41,7 +41,6 @@ public class OsvVulnerabilityRequest {
     public OsvVulnerabilityRequest(OsvPackage osvPackage, String version) {
         Objects.requireNonNull(osvPackage, "Package can not be null");
         this.osvPackage = osvPackage;
-        Objects.requireNonNull(osvPackage, "Version can not be null");
         this.version = version;
         this.commit = null;
     }

--- a/src/test/java/com/sourceauditor/spdx_to_osv/DownloadLocationParserTest.java
+++ b/src/test/java/com/sourceauditor/spdx_to_osv/DownloadLocationParserTest.java
@@ -95,37 +95,37 @@ public class DownloadLocationParserTest {
 		DownloadLocationParser dlp = new DownloadLocationParser(url);
 		Optional<OsvVulnerabilityRequest> osv = dlp.getOsvVulnerabilityRequest();
 		assertTrue(osv.isPresent());
-		assertEquals("tools-java", osv.get().getPackage().getName());
+		assertEquals("github.com/spdx/tools-java", osv.get().getPackage().getName());
 		assertEquals(null, osv.get().getVersion());
-		assertEquals("pkg:github/spdx/tools-java", osv.get().getPackage().getPurl());
-		assertEquals("OSS-Fuzz", osv.get().getPackage().getEcosystem());
+		assertEquals(null, osv.get().getPackage().getPurl());
+		assertEquals(null, osv.get().getPackage().getEcosystem());
 		
 		url = "https://github.com/spdx/tools-java/releases/tag/v1.0.3";
 		dlp = new DownloadLocationParser(url);
 		osv = dlp.getOsvVulnerabilityRequest();
 		assertTrue(osv.isPresent());
-		assertEquals("tools-java", osv.get().getPackage().getName());
+		assertEquals("github.com/spdx/tools-java", osv.get().getPackage().getName());
 		assertEquals("v1.0.3", osv.get().getVersion());
-		assertEquals("pkg:github/spdx/tools-java@v1.0.3", osv.get().getPackage().getPurl());
-		assertEquals("OSS-Fuzz", osv.get().getPackage().getEcosystem());
+		assertEquals(null, osv.get().getPackage().getPurl());
+		assertEquals(null, osv.get().getPackage().getEcosystem());
 		
 		url = "https://github.com/spdx/tools-java.git";
 		dlp = new DownloadLocationParser(url);
 		osv = dlp.getOsvVulnerabilityRequest();
 		assertTrue(osv.isPresent());
-		assertEquals("tools-java", osv.get().getPackage().getName());
+		assertEquals("github.com/spdx/tools-java", osv.get().getPackage().getName());
 		assertEquals(null, osv.get().getVersion());
-		assertEquals("pkg:github/spdx/tools-java", osv.get().getPackage().getPurl());
-		assertEquals("OSS-Fuzz", osv.get().getPackage().getEcosystem());
+        assertEquals(null, osv.get().getPackage().getPurl());
+		assertEquals(null, osv.get().getPackage().getEcosystem());
 		
 		url = "git@github.com:spdx/tools-java.git";
 		dlp = new DownloadLocationParser(url);
 		osv = dlp.getOsvVulnerabilityRequest();
 		assertTrue(osv.isPresent());
-		assertEquals("tools-java", osv.get().getPackage().getName());
+		assertEquals("github.com/spdx/tools-java", osv.get().getPackage().getName());
 		assertEquals(null, osv.get().getVersion());
-		assertEquals("pkg:github/spdx/tools-java", osv.get().getPackage().getPurl());
-		assertEquals("OSS-Fuzz", osv.get().getPackage().getEcosystem());
+        assertEquals(null, osv.get().getPackage().getPurl());
+		assertEquals(null, osv.get().getPackage().getEcosystem());
 		
 		url = "https://github.com/spdx/tools-java/tree/876c0f1ad03210629cf940505b296e242da97b8e";
 		dlp = new DownloadLocationParser(url);
@@ -137,9 +137,9 @@ public class DownloadLocationParserTest {
 		dlp = new DownloadLocationParser(url);
 		osv = dlp.getOsvVulnerabilityRequest();
 		assertTrue(osv.isPresent());
-		assertEquals("tools-java", osv.get().getPackage().getName());
+		assertEquals("github.com/spdx/tools-java", osv.get().getPackage().getName());
 		assertEquals("v1.0.3", osv.get().getVersion());
-		assertEquals("pkg:github/spdx/tools-java@v1.0.3", osv.get().getPackage().getPurl());
-		assertEquals("OSS-Fuzz", osv.get().getPackage().getEcosystem());
+        assertEquals(null, osv.get().getPackage().getPurl());
+		assertEquals(null, osv.get().getPackage().getEcosystem());
 	}
 }


### PR DESCRIPTION
Changes
- Fixes issue in download locator flow where version may be missing, which results in 400 in request to OSV api
- Change heuristic in parsing package name where version may be added on as a suffix